### PR TITLE
Fix packer-manifest missing in builds (#8)

### DIFF
--- a/build/release_body.sh
+++ b/build/release_body.sh
@@ -5,7 +5,7 @@ JQ="$(dirname $0)/third_party/binary/jq"
 
 output_file="$1"
 
-packer_manifests=($(find ./plz-out -name 'manifest.json'))
+packer_manifests=($(find ./plz-out -name 'packer-manifest.json'))
 
 artifact_ids=()
 for packer_manifest in "${packer_manifests[@]}"; do

--- a/build/release_readme.sh
+++ b/build/release_readme.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 
 JQ="$(dirname $0)/third_party/binary/jq"
 
-packer_manifests=($(find ./plz-out -name 'manifest.json'))
+packer_manifests=($(find ./plz-out -name 'packer-manifest.json'))
 
 artifact_ids=()
 

--- a/flavours/arch/xfce4.pkr.hcl
+++ b/flavours/arch/xfce4.pkr.hcl
@@ -70,7 +70,6 @@ EOF
   }
 
   post-processor "manifest" {
-      output = "manifest.json"
       strip_path = true
   }
 

--- a/flavours/debian/kali/xfce4.pkr.hcl
+++ b/flavours/debian/kali/xfce4.pkr.hcl
@@ -53,7 +53,6 @@ build {
   }
 
   post-processor "manifest" {
-      output = "manifest.json"
       strip_path = true
   }
 

--- a/flavours/debian/xfce4.pkr.hcl
+++ b/flavours/debian/xfce4.pkr.hcl
@@ -52,7 +52,6 @@ build {
   }
 
   post-processor "manifest" {
-      output = "manifest.json"
       strip_path = true
   }
 


### PR DESCRIPTION
This was defaulting, but got changed in some places only recently. This
reverts back to the default file name.